### PR TITLE
feat: cache lounge api to speed up /can

### DIFF
--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -805,7 +805,10 @@ class SquadQueue(commands.Cog):
 
     @tasks.loop(minutes=10)
     async def lounge_mmr(self):
-        await lounge_data.lounge_api_full()
+        try:
+            await lounge_data.lounge_api_full()
+        except Exception as e:
+            print(e)
 
     async def schedule_que_event(self):
         """Schedules queue for the next hour in the given channel."""

--- a/mmr.py
+++ b/mmr.py
@@ -5,6 +5,22 @@ from mogi_objects import Player
 headers = {'Content-type': 'application/json'}
 
 
+class LoungeData:
+    def __init__(self):
+        self._data = None
+
+    async def lounge_api_full(self):
+        async with aiohttp.ClientSession() as session:
+            async with session.get("https://www.mk8dx-lounge.com/api/player/list") as response:
+                if response.status == 200:
+                    _data_full = await response.json()
+                    self._data = [player for player in _data_full['players'] if "discordId" in player]
+    
+    def data(self):
+        return self._data
+
+lounge_data = LoungeData()
+
 async def mk8dx_150cc_mmr(url, members):
     base_url = url + '/api/player?'
     players = []


### PR DESCRIPTION
small pr that query the full lounge list every 10 minutes and use it to find data for player canning up, this way /can command will be faster and hopefully won't lag behind when a lot of people can at the same time around 50 minutes.

my motive to make this was the fact that lounge api had small downtime issue but with this cache this would not be an issue anymore, cache will only be 10 minutes behind and I don't think this would be an issue.

It would also reduce deceptive response from the bot when people are filling the last room, since the bot will lock the channel way faster than before 
(I hope this change is enough for the bot to give instant response when people can, maybe if this work well enough the defer on the can command could be removed, but this is probably too early to think about)