### PR TITLE
feat: enabled player api cache with api error handling

### DIFF
--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -182,43 +182,43 @@ class SquadQueue(commands.Cog):
                 await interaction.followup.send(f"{interaction.user.mention} is already signed up.")
                 return
 
-            players = await mk8dx_150cc_mmr(self.URL, [member])
-            # player_api_result = discord.utils.find(
-            #     lambda player: player['discordId'] == str(member.id), lounge_data.data())
+            # players = await mk8dx_150cc_mmr(self.URL, [member])
+            player_api_result = discord.utils.find(
+                lambda player: player['discordId'] == str(member.id), lounge_data.data())
 
-            # if not player_api_result:
-            if len(players) == 0 or players[0] is None:
+            if not player_api_result:
+            # if len(players) == 0 or players[0] is None:
                 msg = f"{interaction.user.mention} fetch for MMR has failed and joining the queue was unsuccessful.  "
                 msg += "Please try again.  If the problem continues then contact a staff member for help."
                 await interaction.followup.send(msg)
                 return
 
-            # player = Player(
-            #     member, player_api_result['name'], player_api_result['mmr'] if 'mmr' in player_api_result else None)
+            player = Player(
+                member, player_api_result['name'], player_api_result['mmr'] if 'mmr' in player_api_result else None)
 
             msg = ""
-            # if player.mmr is None:
-            #     starting_player_mmr = 1500
-            #     player.mmr = starting_player_mmr
-            #     msg += f"{player.lounge_name} is assumed to be a new player and will be playing this mogi with a starting MMR of {starting_player_mmr}.  "
-            #     msg += "If you believe this is a mistake, please contact a staff member for help.\n"
-
-            # player.confirmed = True
-            # squad = Team([player])
-
-            if players[0].mmr is None:
+            if player.mmr is None:
                 starting_player_mmr = 1500
-                players[0].mmr = starting_player_mmr
-                msg += f"{players[0].lounge_name} is assumed to be a new player and will be playing this mogi with a starting MMR of {starting_player_mmr}.  "
+                player.mmr = starting_player_mmr
+                msg += f"{player.lounge_name} is assumed to be a new player and will be playing this mogi with a starting MMR of {starting_player_mmr}.  "
                 msg += "If you believe this is a mistake, please contact a staff member for help.\n"
 
-            players[0].confirmed = True
-            squad = Team(players)
+            player.confirmed = True
+            squad = Team([player])
+
+            # if players[0].mmr is None:
+            #     starting_player_mmr = 1500
+            #     players[0].mmr = starting_player_mmr
+            #     msg += f"{players[0].lounge_name} is assumed to be a new player and will be playing this mogi with a starting MMR of {starting_player_mmr}.  "
+            #     msg += "If you believe this is a mistake, please contact a staff member for help.\n"
+
+            # players[0].confirmed = True
+            # squad = Team(players)
 
             mogi.teams.append(squad)
 
-            # msg += f"{player.lounge_name} joined queue for mogi {discord.utils.format_dt(mogi.start_time, style='R')}, `[{mogi.count_registered()} players]`"
-            msg += f"{players[0].lounge_name} joined queue for mogi {discord.utils.format_dt(mogi.start_time, style='R')}, `[{mogi.count_registered()} players]`"
+            msg += f"{player.lounge_name} joined queue for mogi {discord.utils.format_dt(mogi.start_time, style='R')}, `[{mogi.count_registered()} players]`"
+            # msg += f"{players[0].lounge_name} joined queue for mogi {discord.utils.format_dt(mogi.start_time, style='R')}, `[{mogi.count_registered()} players]`"
 
             await interaction.followup.send(msg)
             await self.check_room_channels(mogi)

--- a/mmr.py
+++ b/mmr.py
@@ -2,7 +2,7 @@ import aiohttp
 import discord
 from mogi_objects import Player
 
-headers = {'Content-type': 'application/json'}
+headers = {"Content-type": "application/json"}
 
 
 class LoungeData:
@@ -11,25 +11,34 @@ class LoungeData:
 
     async def lounge_api_full(self):
         async with aiohttp.ClientSession() as session:
-            async with session.get("https://www.mk8dx-lounge.com/api/player/list") as response:
+            async with session.get(
+                "https://www.mk8dx-lounge.com/api/player/list"
+            ) as response:
                 if response.status == 200:
                     _data_full = await response.json()
-                    self._data = [player for player in _data_full['players'] if "discordId" in player]
-    
+                    if len(_data_full["players"]) == 0:
+                        return
+                    self._data = [
+                        player
+                        for player in _data_full["players"]
+                        if "discordId" in player
+                    ]
+
     def data(self):
         return self._data
 
+
 lounge_data = LoungeData()
 
+
 async def mk8dx_150cc_mmr(url, members):
-    base_url = url + '/api/player?'
+    base_url = url + "/api/player?"
     players = []
     timeout = aiohttp.ClientTimeout(total=10)
     try:
         async with aiohttp.ClientSession(
-            timeout=timeout,
-            auth=aiohttp.BasicAuth(
-                "username", "password")) as session:
+            timeout=timeout, auth=aiohttp.BasicAuth("username", "password")
+        ) as session:
             for member in members:
                 request_text = f"discordId={member.id}"
                 request_url = base_url + request_text
@@ -38,33 +47,32 @@ async def mk8dx_150cc_mmr(url, members):
                         players.append(None)
                         continue
                     player_data = await resp.json()
-                    if 'mmr' not in player_data.keys():
-                        players.append(
-                            Player(member, player_data['name'], None))
+                    if "mmr" not in player_data.keys():
+                        players.append(Player(member, player_data["name"], None))
                         continue
                     players.append(
-                        Player(member, player_data['name'], player_data['mmr']))
+                        Player(member, player_data["name"], player_data["mmr"])
+                    )
     except:
         print(f"Fetch for player {members[0]} has failed.", flush=True)
     return players
 
 
 async def get_mmr_from_discord_id(discord_id):
-    base_url = "https://www.mk8dx-lounge.com" + '/api/player?'
+    base_url = "https://www.mk8dx-lounge.com" + "/api/player?"
     timeout = aiohttp.ClientTimeout(total=10)
     async with aiohttp.ClientSession(
-        timeout=timeout,
-        auth=aiohttp.BasicAuth(
-            "username", "password")) as session:
+        timeout=timeout, auth=aiohttp.BasicAuth("username", "password")
+    ) as session:
         request_text = f"discordId={discord_id}"
         request_url = base_url + request_text
         async with session.get(request_url, headers=headers) as resp:
             if resp.status != 200:
                 return "Player does not exist"
             player_data = await resp.json()
-            if 'mmr' not in player_data.keys():
+            if "mmr" not in player_data.keys():
                 return "Player has no mmr"
-            return player_data['mmr']
+            return player_data["mmr"]
 
 
 async def get_mmr(config, members):
@@ -72,14 +80,14 @@ async def get_mmr(config, members):
 
 
 async def mk8dx_150cc_fc(config, name):
-    base_url = config["url"] + '/api/player?'
-    request_url = base_url + f'name={name}'
+    base_url = config["url"] + "/api/player?"
+    request_url = base_url + f"name={name}"
     timeout = aiohttp.ClientTimeout(total=15)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(request_url, headers=headers) as resp:
             if resp.status != 200:
                 return None
             player_data = await resp.json()
-            if 'switchFc' not in player_data.keys():
+            if "switchFc" not in player_data.keys():
                 return None
-            return player_data['switchFc']
+            return player_data["switchFc"]


### PR DESCRIPTION
hey I run this on quaxly for quite some time without any issue, I made some logging on quaxly to have better idea of what was happening when we talked about this issue long time ago, I did not find any other issue except when the api return 200 with no players, so this fix should prevent the cache from emptying when the api give a bad response that is still a 200.

no pressure to marge this or even implement it, I get it if you guys feel like it's necessary, I mainly did it because I knew it would be slightly better and because I needed to make it for quaxly anyways so I thought it was a free benefit for the queue.

like alway if you have any question hit me up here or on discord, I way more available recently so I may be available to help on some tasks if needed.

ps: little side note but I now do python with black formater, it formated the mmr.py file but I disabled it for the big queue file since the diff would have been a nightmare to read, it could be a good idea to do a formating later if we know everything is fine to make the code base a little bit more readable.